### PR TITLE
docs: replace Smithery badge with LightNow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GitHub Repo MCP
 
-[![smithery badge](https://smithery.ai/badge/@Ryan0204/github-repo-mcp)](https://smithery.ai/server/@Ryan0204/github-repo-mcp)
+[![LightNow capabilities](https://lightnow.ai/badge/io.github.ryan0204/github-repo-mcp)](https://lightnow.ai/servers/io.github.ryan0204/github-repo-mcp)
 
 <p class="center-text">
   <strong>GitHub Repo MCP is an open-source MCP server that lets your AI assistants browse GitHub repositories, explore directories, and view file contents.</strong>


### PR DESCRIPTION
Replaces the broken Smithery badge with LightNow’s live capability badge.

LightNow currently reports **3 T · 0 R · 0 P** for this server.

- [Server listing](https://lightnow.ai/servers/io.github.ryan0204/github-repo-mcp)
- [Badge documentation and variants](https://docs.lightnow.ai/how-to/add-capability-badge)

Testing: `npm run build` (in a network-isolated container).